### PR TITLE
Add charge mode permissions

### DIFF
--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -13,6 +13,6 @@
   "iot_class": "local_polling",
   "loggers": ["homewizard_energy"],
   "quality_scale": "platinum",
-  "requirements": ["python-homewizard-energy==9.3.0"],
+  "requirements": ["python-homewizard-energy==10.0.0"],
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/homeassistant/components/homewizard/select.py
+++ b/homeassistant/components/homewizard/select.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import Any
-
-from homewizard_energy import HomeWizardEnergy
-from homewizard_energy.models import Batteries, CombinedModels as DeviceResponseEntry
+from homewizard_energy.models import Batteries
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
@@ -21,69 +16,63 @@ from .helpers import homewizard_exception_handler
 PARALLEL_UPDATES = 1
 
 
-@dataclass(frozen=True, kw_only=True)
-class HomeWizardSelectEntityDescription(SelectEntityDescription):
-    """Class describing HomeWizard select entities."""
-
-    available_fn: Callable[[DeviceResponseEntry], bool]
-    create_fn: Callable[[DeviceResponseEntry], bool]
-    current_fn: Callable[[DeviceResponseEntry], str | None]
-    set_fn: Callable[[HomeWizardEnergy, str], Awaitable[Any]]
-
-
-DESCRIPTIONS = [
-    HomeWizardSelectEntityDescription(
-        key="battery_group_mode",
-        translation_key="battery_group_mode",
-        entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
-        options=[Batteries.Mode.ZERO, Batteries.Mode.STANDBY, Batteries.Mode.TO_FULL],
-        available_fn=lambda x: x.batteries is not None,
-        create_fn=lambda x: x.batteries is not None,
-        current_fn=lambda x: x.batteries.mode if x.batteries else None,
-        set_fn=lambda api, mode: api.batteries(mode=Batteries.Mode(mode)),
-    ),
-]
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: HomeWizardConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up HomeWizard select based on a config entry."""
-    async_add_entities(
-        HomeWizardSelectEntity(
-            coordinator=entry.runtime_data,
-            description=description,
+    if entry.runtime_data.data.batteries is not None:
+        async_add_entities(
+            [
+                HomeWizardBatteryModeSelectEntity(
+                    coordinator=entry.runtime_data,
+                )
+            ]
         )
-        for description in DESCRIPTIONS
-        if description.create_fn(entry.runtime_data.data)
-    )
 
 
-class HomeWizardSelectEntity(HomeWizardEntity, SelectEntity):
+class HomeWizardBatteryModeSelectEntity(HomeWizardEntity, SelectEntity):
     """Defines a HomeWizard select entity."""
 
-    entity_description: HomeWizardSelectEntityDescription
+    entity_description: SelectEntityDescription
 
     def __init__(
         self,
         coordinator: HWEnergyDeviceUpdateCoordinator,
-        description: HomeWizardSelectEntityDescription,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
+
+        description = SelectEntityDescription(
+            key="battery_group_mode",
+            translation_key="battery_group_mode",
+            entity_category=EntityCategory.CONFIG,
+            entity_registry_enabled_default=(
+                coordinator.data.batteries is not None
+                and coordinator.data.batteries.battery_count is not None
+                and coordinator.data.batteries.battery_count > 0
+            ),
+            options=[
+                str(mode)
+                for mode in (coordinator.data.device.supported_battery_modes() or [])
+            ],
+        )
+
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return self.entity_description.current_fn(self.coordinator.data)
+        return (
+            self.coordinator.data.batteries.mode
+            if self.coordinator.data.batteries
+            else None
+        )
 
     @homewizard_exception_handler
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.entity_description.set_fn(self.coordinator.api, option)
+        await self.coordinator.api.batteries(Batteries.Mode(option))
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/homewizard/strings.json
+++ b/homeassistant/components/homewizard/strings.json
@@ -65,7 +65,9 @@
         "state": {
           "standby": "Standby",
           "to_full": "Manual charge mode",
-          "zero": "Zero mode"
+          "zero": "Zero mode",
+          "zero_charge_only": "Zero mode (charge only)",
+          "zero_discharge_only": "Zero mode (discharge only)"
         }
       }
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2514,7 +2514,7 @@ python-google-weather-api==0.0.4
 python-homeassistant-analytics==0.9.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==9.3.0
+python-homewizard-energy==10.0.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2104,7 +2104,7 @@ python-google-weather-api==0.0.4
 python-homeassistant-analytics==0.9.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==9.3.0
+python-homewizard-energy==10.0.0
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/batteries.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/batteries.json
@@ -1,0 +1,8 @@
+{
+  "mode": "zero",
+  "battery_count": 0,
+  "power_w": 0,
+  "target_power_w": 0,
+  "max_consumption_w": 0,
+  "max_production_w": 0
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/data.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/data.json
@@ -1,0 +1,82 @@
+{
+  "wifi_ssid": "My Wi-Fi",
+  "wifi_strength": 100,
+  "smr_version": 50,
+  "meter_model": "ISKRA  2M550T-101",
+  "unique_id": "00112233445566778899AABBCCDDEEFF",
+  "active_tariff": 2,
+  "total_power_import_kwh": 13779.338,
+  "total_power_import_t1_kwh": 10830.511,
+  "total_power_import_t2_kwh": 2948.827,
+  "total_power_import_t3_kwh": 2948.827,
+  "total_power_import_t4_kwh": 2948.827,
+  "total_power_export_kwh": 13086.777,
+  "total_power_export_t1_kwh": 4321.333,
+  "total_power_export_t2_kwh": 8765.444,
+  "total_power_export_t3_kwh": 8765.444,
+  "total_power_export_t4_kwh": 8765.444,
+  "active_power_w": -123,
+  "active_power_l1_w": -123,
+  "active_power_l2_w": 456,
+  "active_power_l3_w": 123.456,
+  "active_voltage_l1_v": 230.111,
+  "active_voltage_l2_v": 230.222,
+  "active_voltage_l3_v": 230.333,
+  "active_current_l1_a": -4,
+  "active_current_l2_a": 2,
+  "active_current_l3_a": 0,
+  "active_frequency_hz": 50,
+  "voltage_sag_l1_count": 1,
+  "voltage_sag_l2_count": 2,
+  "voltage_sag_l3_count": 3,
+  "voltage_swell_l1_count": 4,
+  "voltage_swell_l2_count": 5,
+  "voltage_swell_l3_count": 6,
+  "any_power_fail_count": 4,
+  "long_power_fail_count": 5,
+  "total_gas_m3": 1122.333,
+  "gas_timestamp": 210314112233,
+  "gas_unique_id": "01FFEEDDCCBBAA99887766554433221100",
+  "active_power_average_w": 123.0,
+  "montly_power_peak_w": 1111.0,
+  "montly_power_peak_timestamp": 230101080010,
+  "active_liter_lpm": 12.345,
+  "total_liter_m3": 1234.567,
+  "external": [
+    {
+      "unique_id": "47303031",
+      "type": "gas_meter",
+      "timestamp": 230125220957,
+      "value": 111.111,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "57303031",
+      "type": "water_meter",
+      "timestamp": 230125220957,
+      "value": 222.222,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "5757303031",
+      "type": "warm_water_meter",
+      "timestamp": 230125220957,
+      "value": 333.333,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "48303031",
+      "type": "heat_meter",
+      "timestamp": 230125220957,
+      "value": 444.444,
+      "unit": "GJ"
+    },
+    {
+      "unique_id": "4948303031",
+      "type": "inlet_heat_meter",
+      "timestamp": 230125220957,
+      "value": 555.555,
+      "unit": "m3"
+    }
+  ]
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/device.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/device.json
@@ -1,0 +1,7 @@
+{
+  "product_type": "HWE-P1",
+  "product_name": "P1 meter",
+  "serial": "5c2fafabcdef",
+  "firmware_version": "4.19",
+  "api_version": "v1"
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-no-batteries/system.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-no-batteries/system.json
@@ -1,0 +1,3 @@
+{
+  "cloud_enabled": true
+}

--- a/tests/components/homewizard/fixtures/HWE-P1/batteries.json
+++ b/tests/components/homewizard/fixtures/HWE-P1/batteries.json
@@ -1,5 +1,6 @@
 {
   "mode": "zero",
+  "battery_count": 2,
   "power_w": -404,
   "target_power_w": -400,
   "max_consumption_w": 1600,

--- a/tests/components/homewizard/snapshots/test_diagnostics.ambr
+++ b/tests/components/homewizard/snapshots/test_diagnostics.ambr
@@ -279,9 +279,12 @@
   dict({
     'data': dict({
       'batteries': dict({
+        'battery_count': 2,
         'max_consumption_w': 1600.0,
         'max_production_w': 800.0,
-        'mode': 'zero',
+        'mode': 'standby',
+        'permissions': list([
+        ]),
         'power_w': -404.0,
         'target_power_w': -400.0,
       }),

--- a/tests/components/homewizard/snapshots/test_select.ambr
+++ b/tests/components/homewizard/snapshots/test_select.ambr
@@ -4,9 +4,9 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Battery group mode',
       'options': list([
-        <Mode.ZERO: 'zero'>,
-        <Mode.STANDBY: 'standby'>,
-        <Mode.TO_FULL: 'to_full'>,
+        'standby',
+        'to_full',
+        'zero',
       ]),
     }),
     'context': <ANY>,
@@ -14,7 +14,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'zero',
+    'state': 'standby',
   })
 # ---
 # name: test_select_entity_snapshots[HWE-P1-select.device_battery_group_mode].1
@@ -24,9 +24,9 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        <Mode.ZERO: 'zero'>,
-        <Mode.STANDBY: 'standby'>,
-        <Mode.TO_FULL: 'to_full'>,
+        'standby',
+        'to_full',
+        'zero',
       ]),
     }),
     'config_entry_id': <ANY>,

--- a/tests/components/homewizard/test_select.py
+++ b/tests/components/homewizard/test_select.py
@@ -275,7 +275,7 @@ async def test_select_multiple_state_changes(
     ("device_fixture", "entity_ids"),
     [
         (
-            "HWE-P1",
+            "HWE-P1-no-batteries",
             [
                 "select.device_battery_group_mode",
             ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add two new modes to ‘Battery group mode’ that allow to let the battery only charge or discharge while keeping it on `zero`.

This is useful for situations where you want the battery to charge so you can use the stored energy on less expensive moments.

This also bumps `python-homewizard-energy` to 10.0.0. Bumping this as separate PR is possible but that may introduce a bug where the list of options contains unsupported values for that specific API version. The `device.supported_battery_modes()` function checks for this. 

- https://github.com/homewizard/python-homewizard-energy/releases/tag/v10.0.0
- https://github.com/homewizard/python-homewizard-energy/compare/v9.3.0...v10.0.0

<img width="326" height="492" alt="image" src="https://github.com/user-attachments/assets/0618d19d-2ee9-4473-877c-5ab28daa0d18" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
