### PR TITLE
Bump python-homewizard-energy to 10.1.0

### DIFF
--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -13,6 +13,6 @@
   "iot_class": "local_polling",
   "loggers": ["homewizard_energy"],
   "quality_scale": "platinum",
-  "requirements": ["python-homewizard-energy==10.0.1"],
+  "requirements": ["python-homewizard-energy==10.1.0"],
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/homeassistant/components/homewizard/strings.json
+++ b/homeassistant/components/homewizard/strings.json
@@ -63,6 +63,7 @@
       "battery_group_mode": {
         "name": "Battery group mode",
         "state": {
+          "predictive": "Smart charge mode",
           "standby": "Standby",
           "to_full": "Manual charge mode",
           "zero": "Zero mode",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2641,7 +2641,7 @@ python-google-weather-api==0.0.6
 python-homeassistant-analytics==0.9.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==10.0.1
+python-homewizard-energy==10.1.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.4.3

--- a/tests/components/homewizard/fixtures/HWE-P1-predictive/batteries.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-predictive/batteries.json
@@ -1,0 +1,9 @@
+{
+  "mode": "zero",
+  "permissions": ["charge_allowed", "discharge_allowed"],
+  "battery_count": 2,
+  "power_w": -404,
+  "target_power_w": -400,
+  "max_consumption_w": 1600,
+  "max_production_w": 800
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-predictive/data.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-predictive/data.json
@@ -1,0 +1,82 @@
+{
+  "wifi_ssid": "My Wi-Fi",
+  "wifi_strength": 100,
+  "smr_version": 50,
+  "meter_model": "ISKRA  2M550T-101",
+  "unique_id": "00112233445566778899AABBCCDDEEFF",
+  "active_tariff": 2,
+  "total_power_import_kwh": 13779.338,
+  "total_power_import_t1_kwh": 10830.511,
+  "total_power_import_t2_kwh": 2948.827,
+  "total_power_import_t3_kwh": 2948.827,
+  "total_power_import_t4_kwh": 2948.827,
+  "total_power_export_kwh": 13086.777,
+  "total_power_export_t1_kwh": 4321.333,
+  "total_power_export_t2_kwh": 8765.444,
+  "total_power_export_t3_kwh": 8765.444,
+  "total_power_export_t4_kwh": 8765.444,
+  "active_power_w": -123,
+  "active_power_l1_w": -123,
+  "active_power_l2_w": 456,
+  "active_power_l3_w": 123.456,
+  "active_voltage_l1_v": 230.111,
+  "active_voltage_l2_v": 230.222,
+  "active_voltage_l3_v": 230.333,
+  "active_current_l1_a": -4,
+  "active_current_l2_a": 2,
+  "active_current_l3_a": 0,
+  "active_frequency_hz": 50,
+  "voltage_sag_l1_count": 1,
+  "voltage_sag_l2_count": 2,
+  "voltage_sag_l3_count": 3,
+  "voltage_swell_l1_count": 4,
+  "voltage_swell_l2_count": 5,
+  "voltage_swell_l3_count": 6,
+  "any_power_fail_count": 4,
+  "long_power_fail_count": 5,
+  "total_gas_m3": 1122.333,
+  "gas_timestamp": 210314112233,
+  "gas_unique_id": "01FFEEDDCCBBAA99887766554433221100",
+  "active_power_average_w": 123.0,
+  "montly_power_peak_w": 1111.0,
+  "montly_power_peak_timestamp": 230101080010,
+  "active_liter_lpm": 12.345,
+  "total_liter_m3": 1234.567,
+  "external": [
+    {
+      "unique_id": "47303031",
+      "type": "gas_meter",
+      "timestamp": 230125220957,
+      "value": 111.111,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "57303031",
+      "type": "water_meter",
+      "timestamp": 230125220957,
+      "value": 222.222,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "5757303031",
+      "type": "warm_water_meter",
+      "timestamp": 230125220957,
+      "value": 333.333,
+      "unit": "m3"
+    },
+    {
+      "unique_id": "48303031",
+      "type": "heat_meter",
+      "timestamp": 230125220957,
+      "value": 444.444,
+      "unit": "GJ"
+    },
+    {
+      "unique_id": "4948303031",
+      "type": "inlet_heat_meter",
+      "timestamp": 230125220957,
+      "value": 555.555,
+      "unit": "m3"
+    }
+  ]
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-predictive/device.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-predictive/device.json
@@ -1,0 +1,7 @@
+{
+  "product_type": "HWE-P1",
+  "product_name": "P1 meter",
+  "serial": "5c2fafabcdef",
+  "firmware_version": "4.19",
+  "api_version": "2.3.0"
+}

--- a/tests/components/homewizard/fixtures/HWE-P1-predictive/system.json
+++ b/tests/components/homewizard/fixtures/HWE-P1-predictive/system.json
@@ -1,0 +1,3 @@
+{
+  "cloud_enabled": true
+}

--- a/tests/components/homewizard/test_select.py
+++ b/tests/components/homewizard/test_select.py
@@ -112,6 +112,12 @@ async def test_select_entity_snapshots(
             Batteries.Mode.TO_FULL,
         ),
         ("HWE-P1", "select.device_battery_group_mode", "zero", Batteries.Mode.ZERO),
+        (
+            "HWE-P1-predictive",
+            "select.device_battery_group_mode",
+            "predictive",
+            Batteries.Mode.PREDICTIVE,
+        ),
     ],
 )
 async def test_select_set_option(
@@ -132,6 +138,13 @@ async def test_select_set_option(
         blocking=True,
     )
     mock_homewizardenergy.batteries.assert_called_with(mode=expected_mode)
+
+
+@pytest.mark.parametrize("device_fixture", ["HWE-P1-predictive"])
+async def test_select_predictive_mode_is_available(hass: HomeAssistant) -> None:
+    """Test that predictive mode is available when supported by the device."""
+    assert (state := hass.states.get("select.device_battery_group_mode"))
+    assert "predictive" in state.attributes["options"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `python-homewizard-energy` to add support for “predictive”. This will automatically be listed when the device is updated to API version 2.3.0 or higher.

https://github.com/homewizard/python-homewizard-energy/releases/tag/v10.1.0
https://github.com/homewizard/python-homewizard-energy/compare/v10.0.1...v10.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] TODO

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
